### PR TITLE
Add basic Windows support

### DIFF
--- a/extension/config.w32
+++ b/extension/config.w32
@@ -1,0 +1,6 @@
+ARG_ENABLE("xhprof", "xhprof support", "no");
+
+if (PHP_XHPROF == "yes") {
+	EXTENSION("xhprof", "xhprof.c", null, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+    AC_DEFINE("HAVE_PCRE", 1, "have pcre headers");
+}


### PR DESCRIPTION
We add the required config.w32, and also use some POSIX compatibility
includes from PHP.  Furthermore, we use `QueryPerformanceCounter()` on
Windows, and optimize the use of `QueryPerformanceFrequency()` by
calling it once on MINIT, and storing the result in a true global
variable.

---

This is just the most basic Windows support. With the patch, xhprof compiles for me locally with PHP 7.3 x64 NTS, but I still have three failing tests; two of them fail due to stack corruption, likely caused by variables being declared as `long` which are usually 8 bytes on *nix, but 4 bytes on Windows. It's probably better to use more portable types, such as `zend_long` or `int64_t`.