### PR TITLE
Add nightly to travis testing matrix and remove unsupported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ notifications:
   email: false
 
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - 7.4
+  - nightly
 
 env:
   global:

--- a/extension/php_xhprof.h
+++ b/extension/php_xhprof.h
@@ -189,8 +189,13 @@ static zend_op_array * (*_zend_compile_file) (zend_file_handle *file_handle, int
 ZEND_DLEXPORT zend_op_array* hp_compile_file(zend_file_handle *file_handle, int type);
 
 /* Pointer to the original compile string function (used by eval) */
+#if PHP_VERSION_ID < 80000
 static zend_op_array * (*_zend_compile_string) (zval *source_string, char *filename);
 ZEND_DLEXPORT zend_op_array* hp_compile_string(zval *source_string, char *filename);
+#else
+static zend_op_array * (*_zend_compile_string) (zval *source_string, const char *filename);
+ZEND_DLEXPORT zend_op_array* hp_compile_string(zval *source_string, const char *filename);
+#endif
 
 /**
  * ****************************

--- a/extension/tests/xhprof_012_8.phpt
+++ b/extension/tests/xhprof_012_8.phpt
@@ -3,7 +3,7 @@ XHProf: Test Curl Additional Info
 Author: longxinhui
 --SKIPIF--
 <?php if (!extension_loaded("curl")) print 'skip'; ?>
-<?php if (PHP_VERSION_ID >= 80000) echo "skip test for php >= 8"; ?>
+<?php if (PHP_VERSION_ID < 80000) echo "skip test for php < 8"; ?>
 --INI--
 xhprof.collect_additional_info = 1
 --FILE--
@@ -25,8 +25,7 @@ echo "\n";
 --EXPECTF--
 main()                                  : ct=       1; wt=*;
 main()==>curl_close                     : ct=       1; wt=*;
-main()==>curl_exec#https://www.php.net/ : ct=       1; wt=*;
-main()==>curl_getinfo                   : ct=       1; wt=*;
+main()==>curl_exec                      : ct=       1; wt=*;
 main()==>curl_init                      : ct=       1; wt=*;
 main()==>curl_setopt                    : ct=       2; wt=*;
 main()==>xhprof_disable                 : ct=       1; wt=*;

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -1226,7 +1226,11 @@ ZEND_DLEXPORT zend_op_array* hp_compile_file(zend_file_handle *file_handle, int 
 /**
  * Proxy for zend_compile_string(). Used to profile PHP eval compilation time.
  */
+#if PHP_VERSION_ID < 80000
 ZEND_DLEXPORT zend_op_array* hp_compile_string(zval *source_string, char *filename)
+#else
+ZEND_DLEXPORT zend_op_array* hp_compile_string(zval *source_string, const char *filename)
+#endif
 {
     if (!XHPROF_G(enabled)) {
         return _zend_compile_string(source_string, filename);
@@ -1532,7 +1536,9 @@ zend_string *hp_trace_callback_curl_exec(zend_string *symbol, zend_execute_data 
             &retval,
             params,
             NULL,
+#if PHP_VERSION_ID < 80000
             1,
+#endif
             1
     };
 


### PR DESCRIPTION
7.0 and 7.1 is unsupported https://www.php.net/supported-versions.php