### PR TITLE
Add missing tests and clean-up md5sum

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -56,48 +56,55 @@
  </notes>
  <contents>
   <dir name="/">
-   <file md5sum="a1fc6022f859d9a134bb250b5c247830" name="examples/sample.php" role="doc" />
-   <file md5sum="8c5b803292bdfa6b179f4811e7cd815c" name="extension/tests/common.php" role="test" />
-   <file md5sum="0ab4de6d2f5f2bedbc68055d9d30f655" name="extension/tests/xhprof_001.phpt" role="test" />
-   <file md5sum="6e89bbe614f60018133166a125061f95" name="extension/tests/xhprof_002.phpt" role="test" />
-   <file md5sum="16839b7fdd547f51f11bddbf2aa0af79" name="extension/tests/xhprof_003.phpt" role="test" />
-   <file md5sum="eb869005932dcb9838b47188f210dbc3" name="extension/tests/xhprof_004_inc.php" role="test" />
-   <file md5sum="2cae986a8f2b7aa2d93085dc2fb55122" name="extension/tests/xhprof_004_require.php" role="test" />
-   <file md5sum="862a700cdcf8299c595dc79fd078b915" name="extension/tests/xhprof_004.phpt" role="test" />
-   <file md5sum="e8f1ad99812846249faa0e5d395c7dcc" name="extension/tests/xhprof_005.phpt" role="test" />
-   <file md5sum="5858600139cd70724597efef94a1d26d" name="extension/tests/xhprof_006.phpt" role="test" />
-   <file md5sum="73b1ed842bd69921bb4b290aa0bf81b7" name="extension/tests/xhprof_007.phpt" role="test" />
-   <file md5sum="36370336430b77fb238d65b392ebe736" name="extension/tests/xhprof_008.phpt" role="test" />
-   <file md5sum="f7803d89ac5bcf1aa29cf001d05215b8" name="extension/config.m4" role="src" />
-   <file md5sum="dae5874eca040b26dbf06d2884d02267" name="extension/config.w32" role="src" />
-   <file md5sum="8cf63963b5febf7d27221aeb8c0737b9" name="extension/php_xhprof.h" role="src" />
-   <file md5sum="45396bac2b65705dc8cc2da520915c96" name="extension/xhprof.c" role="src" />
-   <file md5sum="4bdc15b68407d8c532cecf0e11c192e1" name="xhprof_html/css/xhprof.css" role="src" />
-   <file md5sum="e33901861a482c544d844e98ab2f4bf4" name="xhprof_html/docs/index.html" role="doc" />
-   <file md5sum="af8c89ddcfda42771996d2e488319a2c" name="xhprof_html/docs/sample-callgraph-image.jpg" role="doc" />
-   <file md5sum="814b053339f5ec891fa259d628bab955" name="xhprof_html/docs/sample-diff-report-flat-view.jpg" role="doc" />
-   <file md5sum="21449920a5e2734de467057da3943c4f" name="xhprof_html/docs/sample-diff-report-parent-child-view.jpg" role="doc" />
-   <file md5sum="3367a41600196d26519faeb899c58076" name="xhprof_html/docs/sample-flat-view.jpg" role="doc" />
-   <file md5sum="c28c7cbe02bf758d8e3c8c89ab0205d4" name="xhprof_html/docs/sample-parent-child-view.jpg" role="doc" />
-   <file md5sum="4a4f32413963ef6b5c4e97731cb78002" name="xhprof_html/jquery/indicator.gif" role="src" />
-   <file md5sum="f5445df99e90529a68e51961a7fda4a2" name="xhprof_html/jquery/jquery-1.2.6.js" role="src" />
-   <file md5sum="409f023986f3697d010704b24d2a4dff" name="xhprof_html/jquery/jquery.autocomplete.css" role="src" />
-   <file md5sum="0ccb1b9e7a3356bd5a4791c0e99c5578" name="xhprof_html/jquery/jquery.autocomplete.js" role="src" />
-   <file md5sum="b8c0c8685a199e98eafc6489f3b81734" name="xhprof_html/jquery/jquery.tooltip.css" role="src" />
-   <file md5sum="953460b80a3261b669f048c39c055d77" name="xhprof_html/jquery/jquery.tooltip.js" role="src" />
-   <file md5sum="57b11c66acfdad083f63bed2f277e2c2" name="xhprof_html/js/xhprof_report.js" role="src" />
-   <file md5sum="be62a945b5c6dd8eefc80ac7ded16d64" name="xhprof_html/callgraph.php" role="php" />
-   <file md5sum="3b17e49bf8ac17d6103f9b1cfb0b7d8c" name="xhprof_html/index.php" role="php" />
-   <file md5sum="ce0a5a2c54bd0a68f23b7942f1a19025" name="xhprof_html/typeahead.php" role="php" />
-   <file md5sum="8d5adbece5109664a0d8a2f2c2c34854" name="xhprof_lib/display/typeahead_common.php" role="php" />
-   <file md5sum="3f02285e52055ceb2b1b7072315c2bf7" name="xhprof_lib/display/xhprof.php" role="php" />
-   <file md5sum="02f5dfbe544150fd2bae58e62006085f" name="xhprof_lib/utils/callgraph_utils.php" role="php" />
-   <file md5sum="aeb0a54a04dd69d1cb71684ae4cd5943" name="xhprof_lib/utils/xhprof_lib.php" role="php" />
-   <file md5sum="b3e3e693ff2d4fd0d21e874735cc3dd7" name="xhprof_lib/utils/xhprof_runs.php" role="php" />
-   <file md5sum="eedcc815a0febf81fa0fcfcdd3284912" name="CHANGELOG" role="doc" />
-   <file md5sum="3d359ee6349a3beeebca4a9f9d040d10" name="CREDITS" role="doc" />
-   <file md5sum="c2e81cb961aba4e424dc372175fe5500" name="README.md" role="doc" />
-   <file md5sum="2ee41112a44fe7014dce33e26468ba93" name="LICENSE" role="doc" />
+   <file name="examples/sample.php" role="doc" />
+   <file name="extension/tests/common.php" role="test" />
+   <file name="extension/tests/xhprof_001.phpt" role="test" />
+   <file name="extension/tests/xhprof_002.phpt" role="test" />
+   <file name="extension/tests/xhprof_003.phpt" role="test" />
+   <file name="extension/tests/xhprof_004_inc.php" role="test" />
+   <file name="extension/tests/xhprof_004_require.php" role="test" />
+   <file name="extension/tests/xhprof_004.phpt" role="test" />
+   <file name="extension/tests/xhprof_005.phpt" role="test" />
+   <file name="extension/tests/xhprof_006.phpt" role="test" />
+   <file name="extension/tests/xhprof_007.phpt" role="test" />
+   <file name="extension/tests/xhprof_008.phpt" role="test" />
+   <file name="extension/tests/xhprof_009.phpt" role="test" />
+   <file name="extension/tests/xhprof_010.phpt" role="test" />
+   <file name="extension/tests/xhprof_010_append.php" role="test" />
+   <file name="extension/tests/xhprof_011.phpt" role="test" />
+   <file name="extension/tests/xhprof_011_prepend.php" role="test" />
+   <file name="extension/tests/xhprof_012.phpt" role="test" />
+   <file name="extension/tests/xhprof_013.phpt" role="test" />
+   <file name="extension/config.m4" role="src" />
+   <file name="extension/config.w32" role="src" />
+   <file name="extension/php_xhprof.h" role="src" />
+   <file name="extension/xhprof.c" role="src" />
+   <file name="xhprof_html/css/xhprof.css" role="src" />
+   <file name="xhprof_html/docs/index.html" role="doc" />
+   <file name="xhprof_html/docs/sample-callgraph-image.jpg" role="doc" />
+   <file name="xhprof_html/docs/sample-diff-report-flat-view.jpg" role="doc" />
+   <file name="xhprof_html/docs/sample-diff-report-parent-child-view.jpg" role="doc" />
+   <file name="xhprof_html/docs/sample-flat-view.jpg" role="doc" />
+   <file name="xhprof_html/docs/sample-parent-child-view.jpg" role="doc" />
+   <file name="xhprof_html/jquery/indicator.gif" role="src" />
+   <file name="xhprof_html/jquery/jquery-1.2.6.js" role="src" />
+   <file name="xhprof_html/jquery/jquery.autocomplete.css" role="src" />
+   <file name="xhprof_html/jquery/jquery.autocomplete.js" role="src" />
+   <file name="xhprof_html/jquery/jquery.tooltip.css" role="src" />
+   <file name="xhprof_html/jquery/jquery.tooltip.js" role="src" />
+   <file name="xhprof_html/js/xhprof_report.js" role="src" />
+   <file name="xhprof_html/callgraph.php" role="php" />
+   <file name="xhprof_html/index.php" role="php" />
+   <file name="xhprof_html/typeahead.php" role="php" />
+   <file name="xhprof_lib/display/typeahead_common.php" role="php" />
+   <file name="xhprof_lib/display/xhprof.php" role="php" />
+   <file name="xhprof_lib/utils/callgraph_utils.php" role="php" />
+   <file name="xhprof_lib/utils/xhprof_lib.php" role="php" />
+   <file name="xhprof_lib/utils/xhprof_runs.php" role="php" />
+   <file name="CHANGELOG" role="doc" />
+   <file name="CREDITS" role="doc" />
+   <file name="README.md" role="doc" />
+   <file name="LICENSE" role="doc" />
   </dir>
  </contents>
  <dependencies>


### PR DESCRIPTION
After installing with pecl I got missing tests starting from 009
```diff
+   <file name="extension/tests/xhprof_009.phpt" role="test" />
+   <file name="extension/tests/xhprof_010.phpt" role="test" />
+   <file name="extension/tests/xhprof_010_append.php" role="test" />
+   <file name="extension/tests/xhprof_011.phpt" role="test" />
+   <file name="extension/tests/xhprof_011_prepend.php" role="test" />
+   <file name="extension/tests/xhprof_012.phpt" role="test" />
+   <file name="extension/tests/xhprof_013.phpt" role="test" />
```
Also I removed `md5sum` as looks it populated by pecl