### PR TITLE
Allow to override xhprof.output_dir via env

### DIFF
--- a/xhprof_lib/utils/xhprof_runs.php
+++ b/xhprof_lib/utils/xhprof_runs.php
@@ -91,7 +91,7 @@ class XHProfRuns_Default implements iXHProfRuns {
     // if specified, else we default to the directory
     // in which the error_log file resides.
 
-    if (empty($dir)) {
+    if (empty($dir) && !($dir = getenv('XHPROF_OUTPUT_DIR'))) {
       $dir = ini_get("xhprof.output_dir");
       if (empty($dir)) {
 
@@ -101,7 +101,7 @@ class XHProfRuns_Default implements iXHProfRuns {
                      "Trying {$dir} as default. You can either pass the " .
                      "directory location as an argument to the constructor ".
                      "for XHProfRuns_Default() or set xhprof.output_dir ".
-                     "ini param.");
+                     "ini param, or set XHPROF_OUTPUT_DIR environment variable.");
       }
     }
     $this->dir = $dir;


### PR DESCRIPTION
This is only setting which requires viewer to have the extension installed.

The `XHPROF_OUTPUT_DIR` allows to point viewer scripts to any location - it makes the code reusable for browsing only