### PR TITLE
Make sure xhprof_error doesn't get multiple definition: "Cannot redeclare xhprof_error() (previously declared"

### DIFF
--- a/xhprof_lib/utils/xhprof_lib.php
+++ b/xhprof_lib/utils/xhprof_lib.php
@@ -19,8 +19,10 @@
 // Do not add any display specific code here.
 //
 
-function xhprof_error($message) {
-  error_log($message);
+if (!function_exists('xhprof_error')) {
+  function xhprof_error($message) {
+    error_log($message);
+  }
 }
 
 /*


### PR DESCRIPTION
I kept seeing errors like this at the bottom of the screen when using xhprof:

> Fatal error: Cannot redeclare xhprof_error() (previously declared in /var/www/html/web/xhprof/xhprof_lib/utils/xhprof_lib.php:22) in /var/www/xhprof/xhprof_lib/utils/xhprof_lib.php on line 22

I didn't study why or where it occurs (PHP 7.4) but here's a patch to make sure it doesn't get double-defined.