### PR TITLE
Fix test for PHP 8.2

### DIFF
--- a/extension/tests/xhprof_005.phpt
+++ b/extension/tests/xhprof_005.phpt
@@ -49,7 +49,7 @@ $output = xhprof_disable();
 
 function verify($expected, $actual, $description) {
 
-  echo "Verifying ${description}...\n";
+  echo "Verifying {$description}...\n";
 
   // 25% tolerance
   $range_low = ($expected * 0.75);
@@ -57,10 +57,10 @@ function verify($expected, $actual, $description) {
 
   if (($actual < $range_low) ||
       ($actual > $range_high)) {
-     echo "Failed ${description}. Expected: ${expected} microsecs. ".
-          "Actual: ${actual} microsecs.\n";
+     echo "Failed {$description}. Expected: {$expected} microsecs. ".
+          "Actual: {$actual} microsecs.\n";
   } else {
-     echo "OK: ${description}\n";
+     echo "OK: {$description}\n";
   }
   echo "-------------\n";
 }


### PR DESCRIPTION
The only failure 
```
TEST 5/13 [tests/xhprof_005.phpt]
========DIFF========
001+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /home/skilld/aports/testing/php82-pecl-xhprof/src/xhprof-2.3.5/extension/tests/xhprof_005.php on line 42
002+ 
003+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /home/skilld/aports/testing/php82-pecl-xhprof/src/xhprof-2.3.5/extension/tests/xhprof_005.php on line 50
004+ 
005+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /home/skilld/aports/testing/php82-pecl-xhprof/src/xhprof-2.3.5/extension/tests/xhprof_005.php on line 50
006+ 
007+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /home/skilld/aports/testing/php82-pecl-xhprof/src/xhprof-2.3.5/extension/tests/xhprof_005.php on line 51
008+ 
009+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /home/skilld/aports/testing/php82-pecl-xhprof/src/xhprof-2.3.5/extension/tests/xhprof_005.php on line 53
     Verifying sleep_10000_micro...
     OK: sleep_10000_micro
     -------------
--
========DONE========
FAIL XHProf: Timer Tests
Author: Kannan [tests/xhprof_005.phpt] 
```