### PR TITLE
Nullify references once not used to prevent double-frees

### DIFF
--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -526,6 +526,7 @@ void hp_clean_profiler_state()
 
     if (XHPROF_G(root)) {
         zend_string_release(XHPROF_G(root));
+        XHPROF_G(root) = NULL;
     }
 
     /* Delete the array storing ignored function names */
@@ -1246,6 +1247,7 @@ static void hp_stop()
 
     if (XHPROF_G(root)) {
         zend_string_release(XHPROF_G(root));
+        XHPROF_G(root) = NULL;
     }
 }
 
@@ -1263,6 +1265,7 @@ static inline void hp_array_del(zend_string **names)
         int i = 0;
         for (; names[i] != NULL && i < XHPROF_MAX_IGNORED_FUNCTIONS; i++) {
             zend_string_release(names[i]);
+            names[i] = NULL;
         }
 
         efree(names);


### PR DESCRIPTION
Basically, it looks self-explaining.

In a couple of places, we check if the value is NULL and free() it. 
However, if we start/stop the profiler a couple of times, the next time we (potentially) may not allow the value but still will try to free it and corrupt memory.

The issue with `XHPROF_G(root)` happened on our production, it was corrupting memory in another place (as the freed() chunk was given to another code), the problem with `names[i]` can be seen if we run tests having PHP built with `--enable-debug`.

Could you please take a look and let me know if there's something I can improve?