### PR TITLE
Increase tolerance to latencies

### DIFF
--- a/extension/tests/xhprof_005.phpt
+++ b/extension/tests/xhprof_005.phpt
@@ -51,9 +51,9 @@ function verify($expected, $actual, $description) {
 
   echo "Verifying {$description}...\n";
 
-  // 25% tolerance
+  // 25% tolerance (+ 1.5msec for slow builds)
   $range_low = ($expected * 0.75);
-  $range_high = ($expected * 1.25);
+  $range_high = ($expected * 1.25) + 1500;
 
   if (($actual < $range_low) ||
       ($actual > $range_high)) {


### PR DESCRIPTION
When we build PHP and XHProf without optimisations but with debug (`--enable-debug`), everything becomes much slower than usual, for example, this timing is typically 12512-12600 on my laptop and our build server in such configuration.

It doesn't look like a problem for higher timings (e.g. the following test `usleep(50000)` works fine as it has larger tolerance). I thought that we can allow a bit of extra time to consider the latencies of such builds.