### PR TITLE
Fixed clocks to microseconds conversion on Mac

### DIFF
--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -403,7 +403,7 @@ double get_timebase_conversion()
     mach_timebase_info_data_t info;
     (void) mach_timebase_info(&info);
 
-    return (info.numer / info.denom) * 1000;
+    return info.denom * 1000. / info.numer;
 #endif
 
     return 1.0;


### PR DESCRIPTION
If we take https://opensource.apple.com/source/Libc/Libc-1158.1.2/gen/clock_gettime.c.auto.html for reference,
Indeed, conversion to usecs looks like 
```
mach_timebase_info(&tb_info)
(mach_absolute_time() * tb_info.numer) / tb_info.denom;
```

However, in our case, we store the timebase info and then use it as:

```
mach_absolute_time() / X
```

It looks like to get the same result, `X` should be calculated as:
```
X = tb_info.denom / tb_info.numer; 
```

After this, tests on Mac started passing :)