### PR TITLE
Fix for PHP 8.4 

### DIFF
--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -1286,10 +1286,15 @@ int hp_pcre_match(zend_string *pattern, const char *str, size_t len, zend_ulong 
 #if PHP_VERSION_ID < 70400
         php_pcre_match_impl(pce_regexp, (char*)str, len, &matches, &subparts /* subpats */,
                         0/* global */, 0/* ZEND_NUM_ARGS() >= 4 */, 0/*flags PREG_OFFSET_CAPTURE*/, 0/* start_offset */);
-#else
+#elif PHP_VERSION_ID < 80400
         zend_string *tmp = zend_string_init(str, len, 0);
         php_pcre_match_impl(pce_regexp, tmp, &matches, &subparts /* subpats */,
                             0/* global */, 0/* ZEND_NUM_ARGS() >= 4 */, 0/*flags PREG_OFFSET_CAPTURE*/, 0/* start_offset */);
+        zend_string_release(tmp);
+#else
+        zend_string *tmp = zend_string_init(str, len, 0);
+        php_pcre_match_impl(pce_regexp, tmp, &matches, &subparts /* subpats */,
+                            false/* global */, 0/*flags PREG_OFFSET_CAPTURE*/, 0/* start_offset */);
         zend_string_release(tmp);
 #endif
 

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -1351,15 +1351,14 @@ zend_string *hp_trace_callback_pdo_statement_execute(zend_string *symbol, zend_e
 {
     zend_string *result = NULL;
     zend_string *pattern = NULL;
-    zend_class_entry *pdo_ce;
     zval *object = (data->This.value.obj) ? &(data->This) : NULL;
     zval *query_string, *arg;
 
     if (object != NULL) {
 #if PHP_VERSION_ID < 80000
-        query_string = zend_read_property(pdo_ce, object, "queryString", sizeof("queryString") - 1, 0, NULL);
+        query_string = zend_read_property(NULL, object, "queryString", sizeof("queryString") - 1, 0, NULL);
 #else
-        query_string = zend_read_property(pdo_ce, Z_OBJ_P(object), "queryString", sizeof("queryString") - 1, 0, NULL);
+        query_string = zend_read_property(NULL, Z_OBJ_P(object), "queryString", sizeof("queryString") - 1, 0, NULL);
 #endif
 
         if (query_string == NULL || Z_TYPE_P(query_string) != IS_STRING) {

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -1273,7 +1273,6 @@ static inline void hp_array_del(zend_string **names)
 
 int hp_pcre_match(zend_string *pattern, const char *str, size_t len, zend_ulong idx)
 {
-    zval *match;
     pcre_cache_entry *pce_regexp;
 
     if ((pce_regexp = pcre_get_compiled_regex_cache(pattern)) == NULL) {

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -425,7 +425,6 @@ hp_ignored_functions *hp_ignored_functions_init(zval *values)
 
     if (Z_TYPE_P(values) == IS_ARRAY) {
         HashTable *ht;
-        zend_ulong num_key;
         zend_string *key;
         zval *val;
 
@@ -434,7 +433,7 @@ hp_ignored_functions *hp_ignored_functions_init(zval *values)
 
         names = ecalloc(count + 1, sizeof(zend_string *));
 
-        ZEND_HASH_FOREACH_KEY_VAL(ht, num_key, key, val) {
+        ZEND_HASH_FOREACH_STR_KEY_VAL(ht, key, val) {
             if (!key) {
                 if (Z_TYPE_P(val) == IS_STRING && strcmp(Z_STRVAL_P(val), ROOT_SYMBOL) != 0) {
                     /* do not ignore "main" */

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -393,7 +393,7 @@ void hp_ignored_functions_clear(hp_ignored_functions *functions)
     hp_array_del(functions->names);
     functions->names = NULL;
 
-    memset(functions->filter, 0, XHPROF_MAX_IGNORED_FUNCTIONS);
+    memset(functions->filter, 0, sizeof(functions->filter));
     efree(functions);
 }
 
@@ -457,7 +457,7 @@ hp_ignored_functions *hp_ignored_functions_init(zval *values)
     functions = emalloc(sizeof(hp_ignored_functions));
     functions->names = names;
 
-    memset(functions->filter, 0, XHPROF_MAX_IGNORED_FUNCTIONS);
+    memset(functions->filter, 0, sizeof(functions->filter));
 
     uint32_t i = 0;
     for (; names[i] != NULL; i++) {


### PR DESCRIPTION
- Fix all build warnings
- Fix build failure with 8.4 (php_pcre_match_impl call)

```
=====================================================================
PHP         : /opt/remi/php84/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.4.0alpha1
ZEND_VERSION: 4.4.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 6.9.7-100.fc39.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Jun 27 18:06:32 UTC 2024 x86_64
INI actual  : /work/GIT/pecl-and-ext/xhprof/extension/tmp-php.ini
More .INIs  :  
---------------------------------------------------------------------
PHP         : /opt/remi/php84/root/usr/bin/php-cgi 
PHP_SAPI    : cgi-fcgi
PHP_VERSION : 8.4.0alpha1
ZEND_VERSION: 4.4.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 6.9.7-100.fc39.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Jun 27 18:06:32 UTC 2024 x86_64
INI actual  : /work/GIT/pecl-and-ext/xhprof/extension/tmp-php.ini
More .INIs  : 
--------------------------------------------------------------------- 
CWD         : /work/GIT/pecl-and-ext/xhprof/extension
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2024-07-05 13:39:09
=====================================================================
PASS XHProf: Basic Profiling Test
Author: Kannan [tests/xhprof_001.phpt] 
PASS XHProf: Test (direct and indirect) recursive function calls.
Author: Kannan [tests/xhprof_002.phpt] 
PASS XHProf: Test Class Methods, Constructors, Destructors.
Author: Kannan [tests/xhprof_003.phpt] 
PASS XHProf: Test Include File (load/run_init operations)
Author: Kannan [tests/xhprof_004.phpt] 
PASS XHProf: Timer Tests005.phpt]
Author: Kannan [tests/xhprof_005.phpt] 
PASS XHProf: Basic Sampling Test]
Author: mpal [tests/xhprof_006.phpt] 
PASS XHProf: Test excluding call_user_func and similar functions
Author: mpal [tests/xhprof_007.phpt] 
PASS XHProf: Sampling Mode Testt]
Author: kannan [tests/xhprof_008.phpt] 
PASS XHProf: PHP 5.5 crash in hp_execute_internal
Author: epriestley [tests/xhprof_009.phpt] 
PASS XHProf: Crash with auto_append_file
Author: epriestley [tests/xhprof_010.phpt] 
PASS XHProf: Crash with auto_prepend_file
Author: epriestley [tests/xhprof_011.phpt] 
SKIP XHProf: Test Curl Additional Info
Author: longxinhui [tests/xhprof_012.phpt] 
PASS XHProf: Test Sampling Interval
Author: longxinhui [tests/xhprof_013.phpt] 
=====================================================================
TIME END 2024-07-05 13:39:12

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :     0
Exts tested     :    17
---------------------------------------------------------------------

Number of tests :    13                12
Tests skipped   :     1 (  7.7%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     0 (  0.0%) (  0.0%)
Tests passed    :    12 ( 92.3%) (100.0%)
---------------------------------------------------------------------
Time taken      : 3.491 seconds
=====================================================================

```